### PR TITLE
"Object of type str is not JSON serializable" when making contract

### DIFF
--- a/controllers/contract.py
+++ b/controllers/contract.py
@@ -27,7 +27,7 @@ class ContractController(BaseController):
                 helpers=data.get('helpers'),
                 num_additional_chairs=data['numAdditionalChairs'],
                 signer_email=current_cognito_jwt['email'],  # TODO assert that emails are verified
-                signer_name=current_user,
+                signer_name=str(current_user),
                 artist_phone_number=data['artistPhoneNumber']
                 )
         except NoApproverException:

--- a/controllers/me.py
+++ b/controllers/me.py
@@ -13,7 +13,7 @@ class MeController(BaseController):
     @cognito_auth_required
     @swag_from("swagger/me/get.yaml")
     def get(self) -> FlaskResponseType:
-        result = MeManager().get_user(current_user, current_cognito_jwt)
+        result = MeManager().get_user(str(current_user), current_cognito_jwt)
         return FlaskResponses().success(result)
 
     @cognito_auth_required

--- a/database/users.py
+++ b/database/users.py
@@ -40,7 +40,7 @@ class UsersDB(BaseDB):
         return super().get_database_async()['users']
 
     @classmethod
-    def add_user_contract(cls, uuid: str, contract_id: str) -> bool:
+    def add_user_contract(cls, uuid: str, contract_id: str) -> pymongo.results.UpdateResult:
         return cls.get_collection().update_one(
             {"_id": uuid},
             {"$addToSet": {"contracts": contract_id}}

--- a/database/users.py
+++ b/database/users.py
@@ -41,7 +41,7 @@ class UsersDB(BaseDB):
 
     @classmethod
     def add_user_contract(cls, uuid: str, contract_id: str) -> bool:
-        return cls.get_collection().updateOne(
+        return cls.get_collection().update_one(
             {"_id": uuid},
             {"$addToSet": {"contracts": contract_id}}
         )

--- a/services/docusign/contract_data.py
+++ b/services/docusign/contract_data.py
@@ -35,6 +35,8 @@ class ContractData:
                 text_envelope_args.append(Text(tab_label=key, value=getattr(self, key)))
             elif type(getattr(self, key, None)) == int:
                 number_envelope_args.append(Number(tab_label=key, value=getattr(self, key)))
+            else:
+                raise Exception(f"Invalid key data. '{key}' with value '{getattr(self, key, None)}' with type '{type(getattr(self, key, None))}' can only be a string or int")
 
         # Add helper badge information
         if (self.helpers):


### PR DESCRIPTION
Solution:

We use cognito's `current_user` variable to get the name of the user in the ContractController. This variable mostly behaves like a string but it's actually a `<class 'werkzeug.local.LocalProxy'>` type. This type is not serializable. Casting all `current_user` references to a string fixes this.

Mypy couldn't detect this error because we don't have type definitions for cognito.