### PR TITLE
Cleaned up error checking and throwing

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -9,10 +9,10 @@ class Config():
 
     def get_contract_limit(self, key: str) -> int:
         value = self._config['contract_limits'].get(key)
-        assert type(value) == int, "Invalid config file. Contract limits can only be integers."
+        assert type(value) is int, "Invalid config file. Contract limits can only be integers."
         return value
 
     def get_docusign_config(self, key: str) -> str:
         value = self._config['docusign'].get(key)
-        assert type(value) == str, "Invalid docusign config"
+        assert type(value) is str, "Invalid docusign config"
         return value

--- a/config/env.py
+++ b/config/env.py
@@ -7,7 +7,7 @@ load_dotenv('../backend.env')
 
 def load_env(input: str) -> str:
     data = os.getenv(input)
-    assert type(data) == str and len(data) > 0, f"Invalid or no '{input}' environment variable."
+    assert type(data) is str and len(data) > 0, f"Invalid or no '{input}' environment variable."
     return data
 
 

--- a/controllers/contract.py
+++ b/controllers/contract.py
@@ -56,6 +56,11 @@ class ContractController(BaseController):
                 status_code=status.HTTP_409_CONFLICT,
                 detail='Cannot make contract since there is nobody to approve the contract'
             )
+        except NotImplementedError:
+            raise HTTPException(
+                status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                detail='Unable to create contract of specified type'
+            )
 
         return JSONResponse(
             status_code=status.HTTP_200_OK,

--- a/controllers/me.py
+++ b/controllers/me.py
@@ -75,8 +75,8 @@ class MeController(BaseController):
             ret: bool = await MeManager().create_user(current_user.sub, str(item.vendor_type))
         except DuplicateKeyError:
             raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail="Specified user already exists"
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Specified user already exists"
             )
         if not ret:
             raise HTTPException(

--- a/controllers/me.py
+++ b/controllers/me.py
@@ -11,6 +11,7 @@ from typing import List
 from typing_extensions import TypedDict
 import uuid
 from database.users import UsersDB
+from pymongo.errors import DuplicateKeyError
 
 
 class PostItem(BaseModel):
@@ -70,7 +71,13 @@ class MeController(BaseController):
         )
 
     async def post(self, item: PostItem, current_user: CognitoClaims = Depends(get_current_user)) -> Response:  # type: ignore[no-any-unimported]
-        ret: bool = await MeManager().create_user(current_user.sub, str(item.vendor_type))
+        try:
+            ret: bool = await MeManager().create_user(current_user.sub, str(item.vendor_type))
+        except DuplicateKeyError:
+            raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Specified user already exists"
+            )
         if not ret:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/database/base_db.py
+++ b/database/base_db.py
@@ -1,6 +1,5 @@
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase, AsyncIOMotorCollection
 from config.env import MONGO_URI, MONGO_DB_NAME
-import logging
 from typing import Optional, List
 from utilities.types import MongoMappingType, JSONDict
 
@@ -18,11 +17,7 @@ class BaseDB:
 
     @classmethod
     def _verify_connection(cls, client: AsyncIOMotorClient) -> None:  # type: ignore[no-any-unimported]
-        try:
-            client.server_info()
-        except Exception as e:
-            logging.critical("Cannot connect to db.")
-            raise e
+        client.server_info()
 
     @classmethod
     def get_database(cls) -> AsyncIOMotorDatabase:  # type: ignore[no-any-unimported]

--- a/database/users.py
+++ b/database/users.py
@@ -64,7 +64,7 @@ class UsersDB(BaseDB):
         results = await cls.get_random(cls.get_collection(), 1, query)
         if len(results) == 0:
             return None
-        assert len(results) == 1
+        assert len(results) == 1, "Recieved too many results"
         return results[0]
 
     @classmethod

--- a/managers/contract.py
+++ b/managers/contract.py
@@ -34,8 +34,8 @@ class ContractManager():
         approver_email = "test@gmail.com"
         approver_name = "test"
 
-        assert type(approver_email) == str
-        assert type(approver_name) == str
+        assert type(approver_email) is str, "Expected a string for approver email"
+        assert type(approver_name) is str, "Expected a string for approver name"
 
         data = ContractData(
             num_additional_chairs=num_additional_chairs,

--- a/services/docusign/docusign.py
+++ b/services/docusign/docusign.py
@@ -1,4 +1,3 @@
-import sys
 from .envelope import Contract
 from services.docusign import ContractData
 from docusign_esign import ApiClient
@@ -74,11 +73,11 @@ class Docusign:
 
         envelope_data: Dict[str, str] = Contract(access_token, base_path, account_id).make_contract(contract_data)
 
-        assert type(envelope_data) == dict, f"Invalid envelope response: {envelope_data}"
+        assert type(envelope_data) is dict, f"Invalid envelope response: {envelope_data}"
         assert "envelope_id" in envelope_data, f"Envelope does not contain ID: {envelope_data}"
 
         envelope_id: Optional[str] = envelope_data["envelope_id"]
-        assert type(envelope_id) == str, f"Invalid envelope id {envelope_id} of type {type(envelope_id)}"
+        assert type(envelope_id) is str, f"Invalid envelope id {envelope_id} of type {type(envelope_id)}"
 
         return envelope_id
 

--- a/services/docusign/docusign.py
+++ b/services/docusign/docusign.py
@@ -61,7 +61,7 @@ class Docusign:
                 return callback(api_client, private_key, contract_data)
 
         logging.error(body)
-        sys.exit("Failed to grant consent")  # TODO can this sys.exit be removed?
+        raise Exception("Consent could not be aquired")
 
     @classmethod
     def _run(cls, api_client: ApiClient, private_key: str, contract_data: ContractData) -> str:  # type: ignore[no-any-unimported]


### PR DESCRIPTION
Summary of changes:
- Throwing an Exception instead of `sys.exit()` in `services/docusign/docusign.py`
- Catch a `pymongo.errors.DuplicateKeyError` in `controllers/me.py` in case we attempt to create a user that already exists.
    - Now sends `HTTP_409_CONFLICT` to the user to denote this issue
- Added messages to the assert statements in `managers/contract.py` and `database/users.py`
- Removed the unnecessary try/except statement in `database/base_db.py`, since an error is thrown anyways
    - Removed `logging` import, since it's unnecessary
- Catch a `NotImplementedError` in `controllers/contract.py` and send `HTTP_501_NOT_IMPLEMENTED` to the user
- Changed type-checking to correctly use `is` in place of `==`

closes #28 